### PR TITLE
Add possibility to save with empty required fields

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -37,7 +37,7 @@ class TestSavableViewActivationMixin:
         with FlowTest(SavableFlow, namespace='savable') as flow:
             flow.Task(SavableFlow.start).User('admin').Execute() \
                 .Assert(lambda p: p.created is not None, 'Process did not start.')
-            flow.Task(SavableFlow.savable_task).User('admin').Execute({'text': 'asdf',}) \
+            flow.Task(SavableFlow.savable_task).User('admin').Execute({'text': 'asdf'}) \
                 .Assert(lambda p: p.finished, 'Process is not finished.')
 
     @pytest.mark.django_db
@@ -50,5 +50,5 @@ class TestSavableViewActivationMixin:
             flow.Task(SavableFlow.start).User('admin').Execute() \
                 .Assert(lambda p: p.created is not None, 'Process did not start.')
             with pytest.raises(AssertionError):
-                flow.Task(SavableFlow.savable_task).User('admin').Execute({'text': '',}) \
+                flow.Task(SavableFlow.savable_task).User('admin').Execute({'text': ''}) \
                     .Assert(lambda p: p.finished, 'Process is not finished.')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -6,49 +6,55 @@ from .testapp.flows import SavableFlow
 
 class TestSavableViewActivationMixin:
 
-    @staticmethod
-    def attempt_save(admin_user, post_kwargs):
-        with FlowTest(SavableFlow, namespace='savable') as flow:
-            flow.Task(SavableFlow.start).User('admin').Execute() \
-                .Assert(lambda p: p.created is not None, 'Process did not start.')
-
-            process = SavableFlow.process_class.objects.get()
-            task = process.active_tasks().first()
-            url_args = flow.Task(SavableFlow.savable_task).url_args.copy()
-            task_url = SavableFlow.savable_task.get_task_url(
-                url_type='execute', task=task, user=admin_user, namespace='savable', **url_args)
-            form = flow.app.get(task_url, user=admin_user).form
-
-            for key, value in post_kwargs.items():
-                form[key] = value
-
-            form.submit('_save').follow()
-
-            process.refresh_from_db()
-            assert not process.finished, 'The process is finished.'
-            assert process.text == post_kwargs['text'], 'Text was not saved.'
-
     @pytest.mark.django_db
     def test_save(self, admin_user):
-        self.attempt_save(admin_user, post_kwargs={'text': 'asdf'})
+        with FlowTest(SavableFlow, namespace='savable') as flow:
+            start_process(flow)
+            save_savable_task(flow, admin_user, post_kwargs={'text': 'asdf'})
 
     @pytest.mark.django_db
     def test_default_behavior(self, admin_user):
         with FlowTest(SavableFlow, namespace='savable') as flow:
-            flow.Task(SavableFlow.start).User('admin').Execute() \
-                .Assert(lambda p: p.created is not None, 'Process did not start.')
-            flow.Task(SavableFlow.savable_task).User('admin').Execute({'text': 'asdf'}) \
-                .Assert(lambda p: p.finished, 'Process is not finished.')
+            start_process(flow)
+            execute_savable_task(flow, {'text': 'asdf'})
 
     @pytest.mark.django_db
     def test_save_empty_field(self, admin_user):
-        self.attempt_save(admin_user, post_kwargs={'text': ''})
+        with FlowTest(SavableFlow, namespace='savable') as flow:
+            start_process(flow)
+            save_savable_task(flow, admin_user, post_kwargs={'text': ''})
 
     @pytest.mark.django_db
     def test_done_empty_field_should_fail(self, admin_user):
         with FlowTest(SavableFlow, namespace='savable') as flow:
-            flow.Task(SavableFlow.start).User('admin').Execute() \
-                .Assert(lambda p: p.created is not None, 'Process did not start.')
+            start_process(flow)
             with pytest.raises(AssertionError):
-                flow.Task(SavableFlow.savable_task).User('admin').Execute({'text': ''}) \
-                    .Assert(lambda p: p.finished, 'Process is not finished.')
+                execute_savable_task(flow, {'text': ''})
+
+
+def start_process(flow):
+    flow.Task(SavableFlow.start).User('admin').Execute() \
+        .Assert(lambda p: p.created is not None, 'Process did not start.')
+
+
+def save_savable_task(flow, admin_user, post_kwargs):
+    process = SavableFlow.process_class.objects.get()
+    task = process.active_tasks().first()
+    url_args = flow.Task(SavableFlow.savable_task).url_args.copy()
+    task_url = SavableFlow.savable_task.get_task_url(
+        url_type='execute', task=task, user=admin_user, namespace='savable', **url_args)
+    form = flow.app.get(task_url, user=admin_user).form
+
+    for key, value in post_kwargs.items():
+        form[key] = value
+
+    form.submit('_save').follow()
+
+    process.refresh_from_db()
+    assert not process.finished, 'The process is finished.'
+    assert process.text == post_kwargs['text'], 'Text was not saved.'
+
+
+def execute_savable_task(flow, post_kwargs):
+    flow.Task(SavableFlow.savable_task).User('admin').Execute(post_kwargs) \
+        .Assert(lambda p: p.finished, 'Process is not finished.')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,10 +5,11 @@ from .testapp.flows import SavableFlow
 
 
 class TestSavableViewActivationMixin:
-    @pytest.mark.django_db
-    def test_save(self, admin_user):
+
+    @staticmethod
+    def attempt_save(admin_user, post_kwargs):
         with FlowTest(SavableFlow, namespace='savable') as flow:
-            flow.Task(SavableFlow.start).User('admin').Execute({}) \
+            flow.Task(SavableFlow.start).User('admin').Execute() \
                 .Assert(lambda p: p.created is not None, 'Process did not start.')
 
             process = SavableFlow.process_class.objects.get()
@@ -17,9 +18,7 @@ class TestSavableViewActivationMixin:
             task_url = SavableFlow.savable_task.get_task_url(
                 url_type='execute', task=task, user=admin_user, namespace='savable', **url_args)
             form = flow.app.get(task_url, user=admin_user).form
-            post_kwargs = {
-                'text': 'asdf',
-            }
+
             for key, value in post_kwargs.items():
                 form[key] = value
 
@@ -27,12 +26,29 @@ class TestSavableViewActivationMixin:
 
             process.refresh_from_db()
             assert not process.finished, 'The process is finished.'
-            assert process.text == 'asdf', 'Text was not saved.'
+            assert process.text == post_kwargs['text'], 'Text was not saved.'
+
+    @pytest.mark.django_db
+    def test_save(self, admin_user):
+        self.attempt_save(admin_user, post_kwargs={'text': 'asdf'})
 
     @pytest.mark.django_db
     def test_default_behavior(self, admin_user):
         with FlowTest(SavableFlow, namespace='savable') as flow:
-            flow.Task(SavableFlow.start).User('admin').Execute({}) \
+            flow.Task(SavableFlow.start).User('admin').Execute() \
                 .Assert(lambda p: p.created is not None, 'Process did not start.')
-            flow.Task(SavableFlow.savable_task).User('admin').Execute({}) \
+            flow.Task(SavableFlow.savable_task).User('admin').Execute({'text': 'asdf',}) \
                 .Assert(lambda p: p.finished, 'Process is not finished.')
+
+    @pytest.mark.django_db
+    def test_save_empty_field(self, admin_user):
+        self.attempt_save(admin_user, post_kwargs={'text': ''})
+
+    @pytest.mark.django_db
+    def test_done_empty_field_should_fail(self, admin_user):
+        with FlowTest(SavableFlow, namespace='savable') as flow:
+            flow.Task(SavableFlow.start).User('admin').Execute() \
+                .Assert(lambda p: p.created is not None, 'Process did not start.')
+            with pytest.raises(AssertionError):
+                flow.Task(SavableFlow.savable_task).User('admin').Execute({'text': '',}) \
+                    .Assert(lambda p: p.finished, 'Process is not finished.')

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -3,4 +3,4 @@ from viewflow.models import Process
 
 
 class SavableProcess(Process):
-    text = models.TextField(blank=True)
+    text = models.TextField()

--- a/viewflow_extensions/__init__.py
+++ b/viewflow_extensions/__init__.py
@@ -7,4 +7,4 @@ These are extensions for Django_ Viewflow_.
 
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/viewflow_extensions/views.py
+++ b/viewflow_extensions/views.py
@@ -39,8 +39,7 @@ class SavableViewActivationMixin:
         """If the task was only saved, treat all form fields as not required."""
         form_class = super().get_form_class()
         if self._save:
-            for field in form_class.base_fields.values():
-                field.required = False
+            return make_form_class_without_required_fields(form_class)
         return form_class
 
     def save_task(self):
@@ -61,3 +60,17 @@ class SavableViewActivationMixin:
         if self._save:
             return self.request.get_full_path()
         return super().get_success_url()
+
+
+def make_form_class_without_required_fields(form_class):
+
+    class NoRequiredFieldsForm(form_class):
+
+        required_fields = []
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            for field in self.fields.values():
+                field.required = False
+
+    return NoRequiredFieldsForm

--- a/viewflow_extensions/views.py
+++ b/viewflow_extensions/views.py
@@ -35,12 +35,13 @@ class SavableViewActivationMixin:
         self._save = True if '_save' in request.POST else False
         return super().post(request, *args, **kwargs)
 
-    def get_form_class(self):
+    def get_form(self, form_class=None):
         """If the task was only saved, treat all form fields as not required."""
-        form_class = super().get_form_class()
+        form = super().get_form(form_class)
         if self._save:
-            return make_form_class_without_required_fields(form_class)
-        return form_class
+            for field in form.fields.values():
+                field.required = False
+        return form
 
     def save_task(self):
         """Transition to save the task and return to ``ASSIGNED`` state."""
@@ -60,17 +61,3 @@ class SavableViewActivationMixin:
         if self._save:
             return self.request.get_full_path()
         return super().get_success_url()
-
-
-def make_form_class_without_required_fields(form_class):
-
-    class NoRequiredFieldsForm(form_class):
-
-        required_fields = []
-
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            for field in self.fields.values():
-                field.required = False
-
-    return NoRequiredFieldsForm

--- a/viewflow_extensions/views.py
+++ b/viewflow_extensions/views.py
@@ -29,6 +29,20 @@ class SavableViewActivationMixin:
 
     """
 
+    _save = False
+
+    def post(self, request, *args, **kwargs):
+        self._save = True if '_save' in request.POST else False
+        return super().post(request, *args, **kwargs)
+
+    def get_form_class(self):
+        """If the task was only saved, treat all form fields as not required."""
+        form_class = super().get_form_class()
+        if self._save:
+            for field in form_class.base_fields.values():
+                field.required = False
+        return form_class
+
     def save_task(self):
         """Transition to save the task and return to ``ASSIGNED`` state."""
         task = self.request.activation.task
@@ -37,13 +51,13 @@ class SavableViewActivationMixin:
 
     def activation_done(self, *args, **kwargs):
         """Complete the ``activation`` or save only, depending on form submit."""
-        if '_save' in self.request.POST:
+        if self._save:
             self.save_task()
         else:
             super().activation_done(*args, **kwargs)
 
     def get_success_url(self):
         """Stay at the same page, if the task was only saved."""
-        if '_save' in self.request.POST:
+        if self._save:
             return self.request.get_full_path()
         return super().get_success_url()


### PR DESCRIPTION
#### Description of change

Views inheriting from `SavableViewActivationMixin` allow users to save changes to a task (not complete it) without filling all required fields, as requested in https://github.com/Thermondo/backlog/issues/252.

#### How to test

* Install the package from branch in your environment with backend.
* On backend page, go to tasks in the top-right corner and assign yourself some task, e.g. hydronic balancing.
* Write a comment in the task and press Save. It should save the task with the comment. Without this change, it would complain about missing file which is mandatory.

![task_save2](https://user-images.githubusercontent.com/7900374/32167716-0fad5726-bd6a-11e7-8191-a95d45fd6701.png)
